### PR TITLE
[Git Formats] Add support for line continuation

### DIFF
--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -15,6 +15,31 @@ contexts:
   main:
     - include: references
 
+##[ PROTOTYPES ]#######################################################
+
+  # Trailing slashes can be used to break up long lines. '\' is only legal at
+  # the end of a line, or in an escape such as '\"'. Anywhere else it will cause
+  # a fatal parser error. Comments are not permitted after a trailing slash.
+  line-continuation:
+    - match: (\\)\s*$\n?
+      captures:
+        1: punctuation.separator.continuation.line.git
+    # make sure to resume parsing at next line
+      push:
+        - match: (?=\S|^\s*$)
+          pop: true
+
+  eol-pop:
+    - include: line-continuation
+    - match: $
+      pop: true
+
+  illegal-eol-pop:
+    - include: line-continuation
+    - match: $\n?
+      scope: invalid.illegal.unexpected.eol.git
+      pop: true
+
 ##[ COMMENTS ]#########################################################
 
   comments:
@@ -176,9 +201,7 @@ contexts:
         4: constant.language.pretty-formats.git
         5: keyword.declaration.pretty-formats.git
         6: keyword.operator.assignment.option.pretty-formats.git
-      push:
-        - meta_content_scope: meta.pretty-formats.git
-        - include: include-pretty-formats
+      push: include-pretty-formats
 
   # Link this from contexts where command line options are not highlighted
   pretty-formats-as-arg-minimal:
@@ -190,14 +213,12 @@ contexts:
         # 4: constant.language.pretty-formats.git
         5: keyword.declaration.pretty-formats.git
         6: keyword.operator.assignment.option.pretty-formats.git
-      push:
-        - meta_content_scope: meta.pretty-formats.git
-        - include: include-pretty-formats
+      push: include-pretty-formats
 
   include-pretty-formats:
-    - match: (?=\s)
+    - meta_content_scope: meta.pretty-formats.git
+    - match: (?!\S)
       pop: true
-    - include: pretty-formats
     - match: (\')(?:(t?format)(:))?
       captures:
         1: punctuation.definition.string.begin.shell
@@ -208,6 +229,7 @@ contexts:
         - match: \'
           scope: punctuation.definition.string.end.shell
           pop: true
+        - include: illegal-eol-pop
         - include: pretty-formats
     - match: \"(?:(t?format)(:))?
       captures:
@@ -219,7 +241,9 @@ contexts:
         - match: \"
           scope: punctuation.definition.string.end.shell
           pop: true
+        - include: illegal-eol-pop
         - include: pretty-formats
+    - include: pretty-formats
 
   pretty-formats:
     - match: '%%'
@@ -271,7 +295,6 @@ contexts:
             (\d+)                  # space reserved
             (?:(,)([lm]?trunc))?   # truncation directions
           (\)))
-
       captures:
         1: meta.function-call.pretty-formats.git variable.function.pretty-formats.git
         2: meta.function-call.arguments.pretty-formats.git
@@ -302,23 +325,28 @@ contexts:
           scope: support.constant.color-reset.git.config
 
   pretty-formats-trailers:
-    - match: '%(\()(trailers)(\))'
-      captures:
-        1: punctuation.section.parens.begin.pretty-formats.git
-        2: keyword.other.trailers.pretty-formats.git
-        3: punctuation.section.parens.end.pretty-formats.git
-    - match: '%(\()(trailers)(:)'
+    - match: '(%\()(trailers)'
       captures:
         1: punctuation.section.parens.begin.pretty-formats.git
         2: keyword.other.trailers.pretty-formats.git
       push:
-        - meta_scope: bar
+        - meta_scope: meta.trailers.pretty-formats.git
+        - include: illegal-eol-pop
         - match: \)
           scope: punctuation.section.parens.end.pretty-formats.git
-        - match: ',,|:'
-          scope: invalid.illegal.pretty-formats.git
-        - match: ','
-          scope: punctuation.separator.parameters.pretty-formats.git
-        # Unclear from https://git-scm.com/docs/git-interpret-trailers what other values are valid here
-        - match: only|unfold
-          scope: support.constant.trailer.git.config
+          pop: true
+        - match: ':'
+          scope: keyword.operator.assignment.option.pretty-formats.git
+          push:
+            - include: eol-pop
+            - match: (?=\))
+              pop: true
+            - match: ',,|:'
+              scope: invalid.illegal.pretty-formats.git
+            - match: ','
+              scope: punctuation.separator.parameters.pretty-formats.git
+            # Unclear from https://git-scm.com/docs/git-interpret-trailers what other values are valid here
+            - match: \b(only|unfold)\b
+              scope: support.constant.trailer.git.config
+            - match: \b\w+\b
+              scope: constant.other.trailer.pretty-formats.git

--- a/Git Formats/syntax_test_git_config
+++ b/Git Formats/syntax_test_git_config
@@ -646,3 +646,50 @@ stray-bracket]
 #                                                      ^^^^^^ meta.function-call.arguments.pretty-formats.git
 #                                                            ^^^ constant.other.placeholder.pretty-formats.git
 #                                                                ^ - text.pretty-formats.git
+  foo = --format=tformat:'%(trailers
+#                          ^ punctuation.section.parens.begin.pretty-formats.git
+#                           ^^^^^^^^ keyword.other.trailers.pretty-formats.git
+#                                   ^ invalid.illegal.unexpected.eol.git
+  foo = --format=tformat:'%(trailers)'
+#                          ^ punctuation.section.parens.begin.pretty-formats.git
+#                           ^^^^^^^^ keyword.other.trailers.pretty-formats.git
+#                                   ^ punctuation.section.parens.end.pretty-formats.git
+  foo = --format=tformat:'%(trailers:
+#                          ^ punctuation.section.parens.begin.pretty-formats.git
+#                           ^^^^^^^^ keyword.other.trailers.pretty-formats.git
+#                                   ^ keyword.operator.assignment.option.pretty-formats.git
+#                                    ^ invalid.illegal.unexpected.eol.git
+  foo = --format=tformat:'%(trailers: only
+#                          ^ punctuation.section.parens.begin.pretty-formats.git
+#                           ^^^^^^^^ keyword.other.trailers.pretty-formats.git
+#                                   ^ keyword.operator.assignment.option.pretty-formats.git
+#                                     ^^^^ support.constant.trailer.git.config
+#                                         ^ invalid.illegal.unexpected.eol.git
+  foo = --format=tformat:'%(trailers:)'
+#                          ^ punctuation.section.parens.begin.pretty-formats.git
+#                           ^^^^^^^^ keyword.other.trailers.pretty-formats.git
+#                                   ^ keyword.operator.assignment.option.pretty-formats.git
+#                                    ^ punctuation.section.parens.end.pretty-formats.git
+
+  foo = --format=tformat:'%(trailers: only)
+#                          ^ punctuation.section.parens.begin.pretty-formats.git
+#                           ^^^^^^^^ keyword.other.trailers.pretty-formats.git
+#                                   ^ keyword.operator.assignment.option.pretty-formats.git
+#                                     ^^^^ support.constant.trailer.git.config
+#                                         ^ punctuation.section.parens.end.pretty-formats.git
+  foo = --format=tformat:'%(trailers
+      :
+#     ^ - punctuation.separator
+  foo = --format=tformat:'%(trailers\
+      :
+#     ^ keyword.operator.assignment.option.pretty-formats.git
+#      ^ invalid.illegal.unexpected.eol.git
+  foo = --format=tformat:'%(trailers\
+      :\
+      only)
+#     ^^^^ support.constant.trailer.git.config
+  foo = --format=tformat:'%(trailers\
+      :\
+      only\
+      )
+#     ^ punctuation.section.parens.end.pretty-formats.git


### PR DESCRIPTION
line continuation is added by this commit for

1. quoted pretty-formats
2. trailers

Maybe not yet complete, but just to give some ideas.