### PR TITLE
[Git] Simplify .mailmap

### DIFF
--- a/Git Formats/Git Mailmap.sublime-syntax
+++ b/Git Formats/Git Mailmap.sublime-syntax
@@ -13,7 +13,7 @@ contexts:
   main:
     - include: Git Common.sublime-syntax#comments
     # email reference
-    - match: (<)(\S+?(?:(\@)\S+?(?:(\.)\S+?)?)?)(>)
+    - match: (<)(\S+?(?:(@)\S+?(?:(\.)\S+?)?)?)(>)
       scope: meta.reference.email.git
       captures:
         1: punctuation.definition.reference.email.begin.git

--- a/Git Formats/Git Mailmap.sublime-syntax
+++ b/Git Formats/Git Mailmap.sublime-syntax
@@ -12,14 +12,16 @@ scope: text.git.mailmap
 contexts:
   main:
     - include: Git Common.sublime-syntax#comments
-    - include: Git Common.sublime-syntax#email
-    - match: (<)(\S+?(?:(@)\S+)?)(>)
+    # email reference
+    - match: (<)(\S+?(?:(\@)\S+?(?:(\.)\S+?)?)?)(>)
+      scope: meta.reference.email.git
       captures:
-        0: meta.reference.email.git
         1: punctuation.definition.reference.email.begin.git
         2: entity.name.reference.email.git
         3: punctuation.separator.email.git
-        4: punctuation.definition.reference.email.end.git
-    - match: '[ \t]*([^ \t<#][^<#\n]+?)[ \t]*(?=<|$)'
+        4: punctuation.separator.email.git
+        5: punctuation.definition.reference.email.end.git
+    # proper name
+    - match: ([^ \t<#][^<#\n]+?)[ \t]*(?=<|$)
       captures:
         1: meta.reference.user.git


### PR DESCRIPTION
This PR replaces the external reference to `Git Common.sublime-syntax#email` by an extended version of the existing lazy email pattern, defined in the syntax itself as most of the email parts are already there.

Furthermore it removes matching `[ \t]*` in front of the "proper name" as it does not have any effect.