### PR TITLE
[Git] Fix punctuation in email references

### DIFF
--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -64,14 +64,32 @@ contexts:
 
   email:
     # email reference
-    - match: (<)(\S+(\@)\S+?(\.)[^\s>]+)(>)
-      scope: meta.reference.email.git
-      captures:
-        1: punctuation.definition.reference.email.begin.git
-        2: entity.name.reference.email.git
-        3: punctuation.separator.email.git
-        4: punctuation.separator.email.git
-        5: punctuation.definition.reference.email.end.git
+    - match: <(?=\S+?@\S+?\.\S+?>)
+      scope: punctuation.definition.reference.email.begin.git
+      push: [email-meta, email-name]
+
+  email-meta:
+    - meta_scope: meta.reference.email.git
+    - match: ''
+      pop: true
+
+  email-name:
+    - meta_content_scope: entity.name.reference.email.git
+    - match: '@'
+      scope: punctuation.separator.email.git
+      set: email-domain
+    - include: email-end
+
+  email-domain:
+    - meta_content_scope: entity.name.reference.email.git
+    - match: \.
+      scope: punctuation.separator.email.git
+    - include: email-end
+
+  email-end:
+    - match: '>'
+      scope: punctuation.definition.reference.email.end.git
+      pop: true
 
   username:
     # user reference

--- a/Git Formats/Git Mailmap.sublime-syntax
+++ b/Git Formats/Git Mailmap.sublime-syntax
@@ -12,15 +12,12 @@ scope: text.git.mailmap
 contexts:
   main:
     - include: Git Common.sublime-syntax#comments
-    # email reference
-    - match: (<)(\S+?(?:(@)\S+?(?:(\.)\S+?)?)?)(>)
-      scope: meta.reference.email.git
-      captures:
-        1: punctuation.definition.reference.email.begin.git
-        2: entity.name.reference.email.git
-        3: punctuation.separator.email.git
-        4: punctuation.separator.email.git
-        5: punctuation.definition.reference.email.end.git
+    # lazy email reference
+    - match: <(?=\S+?>)
+      scope: punctuation.definition.reference.email.begin.git
+      push:
+        - Git Common.sublime-syntax#email-meta
+        - Git Common.sublime-syntax#email-name
     # proper name
     - match: ([^ \t<#][^<#\n]+?)[ \t]*(?=<|$)
       captures:

--- a/Git Formats/syntax_test_git_commit
+++ b/Git Formats/syntax_test_git_commit
@@ -32,6 +32,9 @@ Thanks to @username <name@mail-host.domain>.
 #                        ^ punctuation.separator.email.git
 #                                  ^ punctuation.separator.email.git
 #                                         ^ punctuation.definition.reference.email.end.git
+This is a <tag> name <tag.name>
+#         ^^^^^ - meta.reference - entity
+#                    ^^^^^^^^^^ - meta.reference - entity
 Issue user/repo#230 is not closed yet.
 # <- meta.message.git.commit
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.message.git.commit

--- a/Git Formats/syntax_test_git_mailmap
+++ b/Git Formats/syntax_test_git_mailmap
@@ -1,7 +1,7 @@
 # SYNTAX TEST "Git Mailmap.sublime-syntax"
 # <- comment.line.git punctuation.definition.comment.git
 
-<cto@company.xx>                       <cto@coompany.xx> # typos again!
+<cto@company.xx>                       <cto@depart.coompany.xx> # typos again!
 # ^^^^^^^^^^^^^^ meta.reference.email.git
 # <- punctuation.definition.reference.email.begin.git
 # ^^^^^^^^^^^^^ entity.name.reference.email.git
@@ -9,14 +9,15 @@
 #           ^ punctuation.separator.email.git
 #              ^ punctuation.definition.reference.email.end.git
 #               ^^^^^^^^^^^^^^^^^^^^^^^ - meta - entity
-#                                      ^^^^^^^^^^^^^^^^^ meta.reference.email.git
+#                                      ^^^^^^^^^^^^^^^^^^^^^^^^ meta.reference.email.git
 #                                      ^ punctuation.definition.reference.email.begin.git
-#                                       ^^^^^^^^^^^^^^^ entity.name.reference.email.git
+#                                       ^^^^^^^^^^^^^^^^^^^^^^ entity.name.reference.email.git
 #                                          ^ punctuation.separator.email.git
-#                                                   ^ punctuation.separator.email.git
-#                                                      ^ punctuation.definition.reference.email.end.git
-#                                                        ^^^^^^^^^^^^^^^ comment.line.git - meta - entity
-#                                                        ^ punctuation.definition.comment.git
+#                                                 ^ punctuation.separator.email.git
+#                                                          ^ punctuation.separator.email.git
+#                                                             ^ punctuation.definition.reference.email.end.git
+#                                                               ^^^^^^^^^^^^^^^ comment.line.git - meta - entity
+#                                                               ^ punctuation.definition.comment.git
 Some Dude <some@dude.xx>         nick1 <bugs@company.xx>
 # ^^^^^^^ meta.reference.user.git
 #         ^^^^^^^^^^^^^^ meta.reference.email.git


### PR DESCRIPTION
This PR makes sure all dots in the domain name of an email address are scoped as `punctuation.separator.email`. It furthermore enables the syntax to scope the name and domain part differently if desired.

Thoughts?