### PR TITLE
[Git Formats] Optimize MailMap pattern

### DIFF
--- a/Git Formats/Git Mailmap.sublime-syntax
+++ b/Git Formats/Git Mailmap.sublime-syntax
@@ -19,6 +19,5 @@ contexts:
         - Git Common.sublime-syntax#email-meta
         - Git Common.sublime-syntax#email-name
     # proper name
-    - match: ([^ \t<#][^<#\n]+?)[ \t]*(?=<|$)
-      captures:
-        1: meta.reference.user.git
+    - match: '[^ \t<#][^<#\n]+?(?=[ \t]*(<|$))'
+      scope: meta.reference.user.git


### PR DESCRIPTION
This commit removes the capture group from the Git Mailmap syntax. This is pure optimization. ST's sregex engine is known to be 10-13% faster by avoiding `capture`.

**Benchmark:**
   
   - ST 3207
   - Win10
   - A file with 100k lines of: 
      ```
      Some Dude <some@dude.xx>
      ```

**Result:**

   before: 490ms
   after: 440ms  
   faster by: 10%